### PR TITLE
Add 'git_commit_id' label containing the short Git hash.

### DIFF
--- a/src/niva-google-cloud-orb.yml
+++ b/src/niva-google-cloud-orb.yml
@@ -139,10 +139,12 @@ commands:
               if docker images -q "$TEST_CONTAINER_REGISTRY-$container:latest" | grep -E .+; then
                 docker build --cache-from "$TEST_CONTAINER_REGISTRY-$container:latest" \
                 --tag "$TEST_CONTAINER_REGISTRY-$container:$SHORT_GIT_HASH" \
-                --tag "$TEST_CONTAINER_REGISTRY-$container:latest" ${docker_directories[$container]} | cat
+                --tag "$TEST_CONTAINER_REGISTRY-$container:latest" ${docker_directories[$container]} \
+                --build-arg="GIT_COMMIT_ID=$SHORT_GIT_HASH" | cat
               else
                 docker build --tag "$TEST_CONTAINER_REGISTRY-$container:$SHORT_GIT_HASH" \
-                --tag "$TEST_CONTAINER_REGISTRY-$container:latest" ${docker_directories[$container]} | cat
+                --tag "$TEST_CONTAINER_REGISTRY-$container:latest" ${docker_directories[$container]} \
+                --build-arg="GIT_COMMIT_ID=$SHORT_GIT_HASH" | cat
               fi
               echo "s|${image_names[$container]}|$TEST_CONTAINER_REGISTRY-$container:$SHORT_GIT_HASH|g" >> circle_ci_files/sed_subber
               echo "s|build: ${docker_directories[$container]}|image: $TEST_CONTAINER_REGISTRY-$container:$SHORT_GIT_HASH|g" >> circle_ci_files/sed_subber_docker_compose


### PR DESCRIPTION
Because it's nice to have an unambiguous embedded reference to what
source code revision produced this artifact.

---

(This also needs changes to the various Docker files, but the builds won't fail without it, they'll just produce a warning like `[Warning] One or more build-args [GIT_COMMIT_ID] were not consumed`.)

The change needed to *Dockerfile*s is something like this:
```Dockerfile
ARG GIT_COMMIT_ID=unknown
LABEL git_commit_id=$GIT_COMMIT_ID
```

And then you can do for example this...
```bash
docker inspect -f "{{.Config.Labels.git_commit_id}}" myimage
```
...to extract it.