### PR TITLE
Changing to sudo apt-get install google-cloud-sdk-gke-gcloud-auth-plugin

### DIFF
--- a/src/niva-google-cloud-orb.yml
+++ b/src/niva-google-cloud-orb.yml
@@ -204,7 +204,7 @@ commands:
             set -o nounset
             echo ${<< parameters.service_key >>} | base64 --decode --ignore-garbage > gcloud-service-key.json
             set -x
-            gcloud components install gke-gcloud-auth-plugin
+            sudo apt-get install google-cloud-sdk-gke-gcloud-auth-plugin
             gcloud auth activate-service-account --key-file gcloud-service-key.json
             gcloud --quiet config set project ${<< parameters.project >>}
             gcloud --quiet config set compute/zone $GCLOUD_COMPUTE_ZONE


### PR DESCRIPTION
because the Google Cloud CLI component manager is disabled for this installation and gives errors